### PR TITLE
feat: migrate npm publish to OIDC authentication

### DIFF
--- a/.github/workflows/release-live.yml
+++ b/.github/workflows/release-live.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   packages: write
   issues: write
+  id-token: write
 
 jobs:
   audit:
@@ -76,7 +77,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ""
 
   notify_slack:
     needs: [audit, tests, create_release, publish_release]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "tsc --watch",
     "test": "echo \"No tests specified\" && exit 0",
     "release:dev": "npm run lint && npm publish --tag next || (echo 'Release failed' && exit 1)",
-    "release": "npm run lint && npm publish --registry https://registry.npmjs.org/ --access public || (echo 'Release failed' && exit 1)",
+    "release": "npm run lint && npm publish --registry https://registry.npmjs.org/ --access public --provenance || (echo 'Release failed' && exit 1)",
     "format": "prettier nodes credentials --write",
     "lint": "eslint --config eslintrc.js nodes/**/*.ts credentials/**/*.ts package.json",
     "lintfix": "eslint --config eslintrc.js nodes/**/*.ts credentials/**/*.ts package.json --fix",


### PR DESCRIPTION
## Summary
- Migrate npm publishing from `NPM_TOKEN` secret to OIDC-based provenance authentication
- Add `id-token: write` permission to `release-live.yml` workflow
- Add `--provenance` flag to `npm publish` command in `package.json`
- Set `NODE_AUTH_TOKEN` to empty string to force OIDC mode